### PR TITLE
Disable catkin for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,13 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(serial)
 
-# Find catkin
-find_package(catkin REQUIRED)
+#Catkin is not required at all in modern cmake, dependencies are handled fine through target_link_libraries.
+#We set the default to be on to not break anyone's builds.
+option(SERIAL_ENABLE_CATKIN "Enable using the Catkin make extension to cmake (ie for ROS)" ON)
+if(${SERIAL_ENABLE_CATKIN})
+    # Find catkin
+    find_package(catkin REQUIRED)
+endif()
 
 if(APPLE)
     find_library(IOKIT_LIBRARY IOKit)
@@ -13,17 +18,21 @@ if(UNIX AND NOT APPLE)
     # If Linux, add rt and pthread
     set(rt_LIBRARIES rt)
     set(pthread_LIBRARIES pthread)
-    catkin_package(
-        LIBRARIES ${PROJECT_NAME}
-        INCLUDE_DIRS include
-        DEPENDS rt pthread
-    )
+    if(${SERIAL_ENABLE_CATKIN})
+        catkin_package(
+            LIBRARIES ${PROJECT_NAME}
+            INCLUDE_DIRS include
+            DEPENDS rt pthread
+        )
+    endif()
 else()
     # Otherwise normal call
-    catkin_package(
-        LIBRARIES ${PROJECT_NAME}
-        INCLUDE_DIRS include
-    )
+    if(${SERIAL_ENABLE_CATKIN})
+        catkin_package(
+            LIBRARIES ${PROJECT_NAME}
+            INCLUDE_DIRS include
+        )
+    endif()
 endif()
 
 ## Sources
@@ -61,21 +70,62 @@ add_executable(serial_example examples/serial_example.cc)
 add_dependencies(serial_example ${PROJECT_NAME})
 target_link_libraries(serial_example ${PROJECT_NAME})
 
-## Include headers
-include_directories(include)
 
-## Install executable
-install(TARGETS ${PROJECT_NAME}
-    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-)
 
-## Install headers
-install(FILES include/serial/serial.h include/serial/v8stdint.h
-  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/serial)
+if(${SERIAL_ENABLE_CATKIN})
+    ## Include headers
+    include_directories(include)
+    ## Install executable
+    install(TARGETS ${PROJECT_NAME}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+    )
 
-## Tests
-if(CATKIN_ENABLE_TESTING)
-    add_subdirectory(tests)
+    ## Install headers
+    install(FILES include/serial/serial.h include/serial/v8stdint.h
+      DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/serial)
+    ## Tests
+    if(CATKIN_ENABLE_TESTING)
+        add_subdirectory(tests)
+    endif()
+else()
+    # while some of this uses stuff from newer CMake versions, the code before already ignored 2.8 compat,
+    # so we ignore it here as well.
+    # see this: https://www.youtube.com/watch?v=m0DwB4OvDXk and associated slides hosted on github to learn more. 
+    include(GNUInstallDirs)
+    target_include_directories(${PROJECT_NAME} PUBLIC
+            $<INSTALL_INTERFACE:include>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+    # Install targets
+    install(TARGETS ${PROJECT_NAME}
+            EXPORT ${PROJECT_NAME}Targets
+            INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                    COMPONENT ${PROJECT_NAME}_RunTime
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                    COMPONENT ${PROJECT_NAME}_RunTime
+                    NAMELINK_COMPONENT ${PROJECT_NAME}_Development
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                    COMPONENT ${PROJECT_NAME}_Development
+
+            )
+    # Install header files
+    install(FILES
+            ${CMAKE_CURRENT_SOURCE_DIR}/include/serial/serial.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/include/serial/v8stdint.h
+            DESTINATION
+            ${CMAKE_INSTALL_INCLUDEDIR})
+
+    # Install cmake stuff so we can use our target
+    install(EXPORT ${PROJECT_NAME}Targets
+            FILE ${PROJECT_NAME}Targets.cmake
+            NAMESPACE ${PROJECT_NAME}::
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+            )
+    option(SERIAL_ENABLE_TESTING "Enable testing" OFF)
+    if(${SERIAL_ENABLE_TESTING})
+        add_subdirectory(tests)
+    endif()
 endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 2.8.3)
 project(serial)
 
 #Catkin is not required at all in modern cmake, dependencies are handled fine through target_link_libraries.
-#We set the default to be on to not break anyone's builds.
-option(SERIAL_ENABLE_CATKIN "Enable using the Catkin make extension to cmake (ie for ROS)" ON)
+#I'm changing the default option to off since my team is not using ROS here.
+option(SERIAL_ENABLE_CATKIN "Enable using the Catkin make extension to cmake (ie for ROS)" OFF)
 if(${SERIAL_ENABLE_CATKIN})
     # Find catkin
     find_package(catkin REQUIRED)


### PR DESCRIPTION
I'm merging into the `main` branch to avoid needing to switch branches before compiling the library.